### PR TITLE
Fixed an issue with ignored options causing CommandLineParserException if they have no setter

### DIFF
--- a/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
@@ -41,14 +41,14 @@ namespace System.Reflection
             {
                 throw new ArgumentNullException("options");
             }
+            if (propertySource.ShouldBeIgnored())
+            {
+                return null;
+            }
             if (!propertySource.IsValidOptionProperty())
             {
                 throw new CommandLineParserException(string.Format(CultureInfo.CurrentUICulture, "The option '{0}' of the command '{1}' must be writable or implements ICollection<T>.",
                                                                    propertySource.Name, commandMetadataTemplate.Name));
-            }
-            if (propertySource.ShouldBeIgnored())
-            {
-                return null;
             }
             var metadata = new OptionMetadataTemplate(propertySource, commandMetadataTemplate);
 


### PR DESCRIPTION
I've ran into an exception with the following command code:

```
public class MyCommand : CommandBase{ 
   [IgnoreOptionProperty]
   public string Name { get { return "my name"; } }
}
```

The `Name` property has no setter but it's decorated with `IgnoreOptionPropertyAttribute` so it should not cause any trouble, but it did. Check for `IgnoreOptionPropertyAttribute` has been placed after option property validation code so it misfired.
I've fixed the issue by moving 4 lines of code :)
