### PR TITLE
Add support of response file

### DIFF
--- a/src/MGR.CommandLineParser/DefaultConsole.cs
+++ b/src/MGR.CommandLineParser/DefaultConsole.cs
@@ -129,7 +129,7 @@ namespace MGR.CommandLineParser
                 var length = Math.Min(value.Length, maxWidth);
                 // Text we can print without overflowing the System.Console.
                 var content = value.Substring(0, length);
-                var leftPadding = startIndex + length - CursorLeft;
+                var leftPadding = Math.Max(startIndex + length - CursorLeft, 0);
                 // Print it with the correct padding
                 Console.WriteLine(content.PadLeft(leftPadding));
                 // Get the next substring to be printed

--- a/src/MGR.CommandLineParser/Extensions/EnumerableExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+
+// ReSharper disable once CheckNamespace
+namespace System.Collections.Generic
+{
+    internal static class EnumerableExtensions
+    {
+        internal static IEnumerator<string> GetArgumentEnumerator([NotNull]this IEnumerable<string> arguments)
+        {
+            var enumerable = arguments as IList<string> ?? arguments.ToList();
+            var firstArgument = enumerable.FirstOrDefault();
+            if (string.IsNullOrEmpty(firstArgument))
+            {
+                return enumerable.GetEnumerator();
+            }
+            if (firstArgument.StartsWith("@", StringComparison.CurrentCulture))
+            {
+                if (!firstArgument.StartsWith("@@", StringComparison.CurrentCulture))
+                {
+                    var responseFileName = firstArgument.Remove(0, 1);
+                    if (Path.GetExtension(responseFileName) == ".rsp" && File.Exists(responseFileName))
+                    {
+                        var responseFileContent = File.ReadAllLines(responseFileName);
+                        return responseFileContent.AsEnumerable().GetEnumerator();
+                    }
+                }
+                var firstArgumentWithoutArobase = firstArgument.Remove(0, 1);
+                return new[] { firstArgumentWithoutArobase }.Concat(enumerable.Skip(1)).GetEnumerator();
+            }
+            return enumerable.GetEnumerator();
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/MGR.CommandLineParser.csproj
+++ b/src/MGR.CommandLineParser/MGR.CommandLineParser.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Extensions\ConverterAttributeExtensions.cs" />
     <Compile Include="Extensions\ConverterExtensions.cs" />
     <Compile Include="Extensions\DependencyResolverScopeExtensions.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\PropertyInfoExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />

--- a/src/MGR.CommandLineParser/Parser.cs
+++ b/src/MGR.CommandLineParser/Parser.cs
@@ -42,7 +42,7 @@ namespace MGR.CommandLineParser
             var currentDependencyResolver = DependencyResolver.Current.CreateScope();
             var commandTypeProvider = currentDependencyResolver.ResolveDependency<ICommandTypeProvider>();
             var commandType = commandTypeProvider.GetCommandType<TCommand>();
-            var argsEnumerator = args.GetEnumerator();
+            var argsEnumerator = args.GetArgumentEnumerator();
             var parsingResult = ParseImpl(argsEnumerator, currentDependencyResolver, commandType);
             if (parsingResult.Command == null)
             {
@@ -63,7 +63,7 @@ namespace MGR.CommandLineParser
                 return new CommandResult<ICommand>(null, CommandResultCode.NoArgs);
             }
             var currentDependencyResolver = DependencyResolver.Current.CreateScope();
-            var argsEnumerator = args.GetEnumerator();
+            var argsEnumerator = args.GetArgumentEnumerator();
             var commandName = GetNextCommandLineItem(argsEnumerator);
             if (commandName == null)
             {

--- a/tests/MGR.CommandLineParser.IntegrationTests/ParsingTests/ParseCommandTests/ParseInstallCommandTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/ParsingTests/ParseCommandTests/ParseInstallCommandTests.cs
@@ -1,6 +1,42 @@
-﻿namespace MGR.CommandLineParser.Integration.Tests.ParsingTests.ParseCommandTests
+﻿using System.IO;
+using MGR.CommandLineParser.Tests.Commands;
+using Xunit;
+
+namespace MGR.CommandLineParser.IntegrationTests.ParsingTests.ParseCommandTests
 {
     public class ParseInstallCommandTests
     {
+        [Fact]
+        public void ParseWithAResponseFile()
+        {
+            // Arrange
+            var parser = new ParserBuilder().BuildParser();
+            var tempFile = Path.GetRandomFileName();
+            var tempResponseFileName = Path.ChangeExtension(tempFile, ".rsp");
+            var tempFolder = Path.GetTempPath();
+            var tempResponseFile = Path.Combine(tempFolder, tempResponseFileName);
+            File.WriteAllLines(tempResponseFile, new[]
+            {
+                "install",
+                "-version:12.34",
+                "-excludeVersion"
+            });
+
+            // Act
+            var actual = parser.Parse(new[] {"@" + tempResponseFile});
+
+            // Assert
+            Assert.True(actual.IsValid);
+            Assert.Empty(actual.ValidationResults);
+            Assert.IsType<InstallCommand>(actual.Command);
+            var installCommand = (InstallCommand) actual.Command;
+            Assert.Empty(installCommand.Source);
+            Assert.True(string.IsNullOrEmpty(installCommand.OutputDirectory));
+            Assert.Equal("12.34", installCommand.Version);
+            Assert.True(installCommand.ExcludeVersion);
+            Assert.False(installCommand.Prerelease);
+            Assert.False(installCommand.NoCache);
+            Assert.Empty(installCommand.Arguments);
+        }
     }
 }


### PR DESCRIPTION
This fixes #21.
The response file must be the first argument and start with a `@`. To supply a argument with an `@`, just double it.