### PR TITLE
Change the way the version is computed

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -60,7 +60,7 @@ if (!(Test-Path $CAKE_EXE)) {
 }
 
 # Start Cake
-$CakeInvokeExpression = "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseDryRun $UseExperimental -mygetFeed=`"$MyGetFeed`" -buildNumber=`"$BuildNumber`""
+$CakeInvokeExpression = "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseDryRun $UseExperimental -mygetFeed=`"$MyGetFeed`""
 Invoke-Expression $CakeInvokeExpression 
 Write-Host
 exit $LASTEXITCODE


### PR DESCRIPTION
fixes #57 

- Compute the name of the branch by looking at the AppVeyor variable then the GitVersion
- Compute version only outside of PR building