### PR TITLE
Split command option descriptor

### DIFF
--- a/src/MGR.CommandLineParser/Command/CommandOption.cs
+++ b/src/MGR.CommandLineParser/Command/CommandOption.cs
@@ -2,17 +2,17 @@
 using System.Collections.Generic;
 using System.Reflection;
 using JetBrains.Annotations;
-using MGR.CommandLineParser.Command;
+using MGR.CommandLineParser.Extensibility.Command;
 using MGR.CommandLineParser.Extensibility.Converters;
 
-namespace MGR.CommandLineParser.Extensibility.Command
+namespace MGR.CommandLineParser.Command
 {
     /// <summary>
     ///     Represents an option of a command.
     /// </summary>
-    public sealed class CommandOption
+    internal sealed class CommandOption : ICommandOption
     {
-        private readonly MethodInfo _miAddMethod ;
+        private readonly MethodInfo _miAddMethod;
         private CommandOption(PropertyInfo propertyInfo, ICommandMetadata commandMetadata, List<IConverter> converters)
         {
             PropertyOption = propertyInfo;
@@ -28,7 +28,7 @@ namespace MGR.CommandLineParser.Extensibility.Command
         /// </summary>
         [NotNull]
         public OptionDisplayInfo DisplayInfo { get; }
-        
+
         /// <summary>
         ///     Gets the converter for the option.
         /// </summary>
@@ -88,11 +88,19 @@ namespace MGR.CommandLineParser.Extensibility.Command
                 AssignValueInternal(DefaultValue, command);
             }
         }
-        internal void AssignValue(string optionValue, ICommand command)
+
+        public bool OptionalValue => OptionType == typeof(bool);
+
+        public void AssignValue(string optionValue, ICommand command)
         {
             if (!OptionType.IsType(Converter.TargetType))
             {
                 throw new CommandLineParserException(Constants.ExceptionMessages.ParserSpecifiedConverterNotValidToAssignValue(OptionType, Converter.TargetType));
+            }
+
+            if (OptionType == typeof(bool) && optionValue == null)
+            {
+                optionValue = true.ToString();
             }
             var convertedValue = ConvertValue(optionValue);
             AssignValueInternal(convertedValue, command);

--- a/src/MGR.CommandLineParser/Command/CommandOptionMetadata.cs
+++ b/src/MGR.CommandLineParser/Command/CommandOptionMetadata.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using MGR.CommandLineParser.Extensibility.Command;
+
+namespace MGR.CommandLineParser.Command
+{
+    internal class CommandOptionMetadata: ICommandOptionMetadata
+    {
+        public CommandOptionMetadata(PropertyInfo propertyInfo)
+        {
+            DisplayInfo =  new OptionDisplayInfo(propertyInfo);
+            IsRequired = propertyInfo.ExtractIsRequiredMetadata();
+            DefaultValue = propertyInfo.ExtractDefaultValue();
+            CollectionType = GetMultiValueIndicator(propertyInfo);
+        }
+        public bool IsRequired { get; }
+        public CommandOptionCollectionType CollectionType { get; }
+        public OptionDisplayInfo DisplayInfo { get; }
+        public string DefaultValue { get; }
+
+        internal static CommandOptionMetadata Create(PropertyInfo propertyInfo, ICommandMetadata commandMetadata)
+        {
+            Guard.NotNull(propertyInfo, nameof(propertyInfo));
+            Guard.NotNull(commandMetadata, nameof(commandMetadata));
+
+            if (propertyInfo.ShouldBeIgnored())
+            {
+                return null;
+            }
+            if (!propertyInfo.IsValidOptionProperty())
+            {
+                throw new CommandLineParserException(
+                    Constants.ExceptionMessages.ParserExtractMetadataPropertyShouldBeWritableOrICollection(
+                        propertyInfo.Name, commandMetadata.Name));
+            }
+            var commandOptionMetadata = new CommandOptionMetadata(propertyInfo);
+            return commandOptionMetadata;
+        }
+
+        internal static CommandOptionCollectionType GetMultiValueIndicator(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.PropertyType.IsDictionaryType())
+            {
+                return CommandOptionCollectionType.Dictionary;
+            }
+            if (propertyInfo.PropertyType.IsCollectionType())
+            {
+                return CommandOptionCollectionType.Collection;
+            }
+            return CommandOptionCollectionType.None;
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/Command/Option.cs
+++ b/src/MGR.CommandLineParser/Command/Option.cs
@@ -1,0 +1,16 @@
+﻿using MGR.CommandLineParser.Extensibility.Command;
+
+namespace MGR.CommandLineParser.Command
+{
+    internal sealed class Option
+    {
+        public Option(ICommandOption commandOption, ICommandOptionMetadata commandOptionMetadata)
+        {
+            CommandOption = commandOption;
+            CommandOptionMetadata = commandOptionMetadata;
+        }
+
+        public ICommandOption CommandOption { get; }
+        public ICommandOptionMetadata CommandOptionMetadata { get; }
+    }
+}

--- a/src/MGR.CommandLineParser/Command/WrapCommandOption.cs
+++ b/src/MGR.CommandLineParser/Command/WrapCommandOption.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MGR.CommandLineParser.Extensibility.Command;
+
+namespace MGR.CommandLineParser.Command
+{
+    internal class WrapCommandOption : ICommandOption
+    {
+        private readonly string _commandName;
+        private readonly IEnumerable<ICommandOption> _commandOptions;
+        private readonly string _optionText;
+
+        public WrapCommandOption(string optionText, string commandName, params ICommandOption[] commandOptions)
+        {
+            _commandOptions = commandOptions;
+            _optionText = optionText;
+            _commandName = commandName;
+        }
+
+        public bool OptionalValue => _commandOptions.Aggregate(true, (optionalValue, commandOption) => optionalValue && commandOption.OptionalValue);
+
+        public void AssignValue(string optionValue, ICommand command)
+        {
+            if (!OptionalValue && optionValue == null)
+            {
+                throw new CommandLineParserException(Constants.ExceptionMessages.FormatParserOptionValueRequired(_commandName, _optionText));
+            }
+
+            foreach (var commandOption in _commandOptions)
+            {
+                commandOption.AssignValue(optionValue, command);
+            }
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/CommandType.cs
+++ b/src/MGR.CommandLineParser/CommandType.cs
@@ -16,8 +16,7 @@ namespace MGR.CommandLineParser
     internal sealed class CommandType : ICommandType
     {
         private readonly Lazy<CommandMetadata> _commandMetadata;
-        private readonly Lazy<List<ICommandOptionMetadata>> _commandOptionMetadatas;
-        private readonly Lazy<List<CommandOption>> _commandOptions;
+        private readonly Lazy<List<Option>> _commandOptions;
         /// <summary>
         /// Creates a new <see cref="CommandType"/>.
         /// </summary>
@@ -27,8 +26,7 @@ namespace MGR.CommandLineParser
         {
             Type = commandType;
             _commandMetadata = new Lazy<CommandMetadata>(() => new CommandMetadata(Type));
-            _commandOptionMetadatas = new Lazy<List<ICommandOptionMetadata>>(() => new List<ICommandOptionMetadata>(ExtractCommandOptionMetadatas(Type, Metadata)));
-            _commandOptions = new Lazy<List<CommandOption>>(() => new List<CommandOption>(ExtractCommandOptions(Type, Metadata, converters.ToList())));
+            _commandOptions = new Lazy<List<Option>>(() => new List<Option>(ExtractCommandOptions(Type, Metadata, converters.ToList())));
 
         }
         /// <summary>
@@ -43,25 +41,50 @@ namespace MGR.CommandLineParser
         /// <summary>
         /// Gets the option of the command type.
         /// </summary>
-        public IEnumerable<ICommandOptionMetadata> Options => _commandOptionMetadatas.Value;
+        public IEnumerable<ICommandOptionMetadata> Options => _commandOptions.Value.Select(option => option.CommandOptionMetadata);
+
+        internal IEnumerable<ICommandOption> CommandOptions => _commandOptions.Value.Select(option => option.CommandOption);
+
         /// <inheritdoc />
-        public CommandOption FindOption(string optionName)
+        public ICommandOption FindOption(string optionName)
         {
-            var om = _commandOptions.Value.FirstOrDefault(option => option.DisplayInfo.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase));
-            if (om != null)
+            var unwrappedOption = FindUnwrappedOption(optionName);
+            if (unwrappedOption != null)
             {
-                return om;
+                return new WrapCommandOption(optionName, Metadata.Name, unwrappedOption);
             }
-            var alternateOption = _commandOptions.Value.FirstOrDefault(option => option.DisplayInfo.AlternateNames.Any(alternateName => alternateName.Equals(optionName, StringComparison.OrdinalIgnoreCase)));
-            return alternateOption;
+
+            return null;
         }
 
-        public CommandOption FindOptionByShortName(string optionShortName)
+        private ICommandOption FindUnwrappedOption(string optionName)
         {
-            var shortOption = _commandOptions.Value.FirstOrDefault(option => (option.DisplayInfo.ShortName ?? string.Empty).Equals(optionShortName, StringComparison.OrdinalIgnoreCase));
+            var om = _commandOptions.Value.FirstOrDefault(option => option.CommandOptionMetadata.DisplayInfo.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase));
+            if (om != null)
+            {
+                return om.CommandOption;
+            }
+            var alternateOption = _commandOptions.Value.FirstOrDefault(option => option.CommandOptionMetadata.DisplayInfo.AlternateNames.Any(alternateName => alternateName.Equals(optionName, StringComparison.OrdinalIgnoreCase)));
+            return alternateOption?.CommandOption;
+        }
+
+        public ICommandOption FindOptionByShortName(string optionShortName)
+        {
+            var unwrappedOption = FindUnwrappedOptionByShortName(optionShortName);
+            if (unwrappedOption != null)
+            {
+                return new WrapCommandOption(optionShortName, Metadata.Name, unwrappedOption);
+            }
+
+            return null;
+        }
+
+        private ICommandOption FindUnwrappedOptionByShortName(string optionShortName)
+        {
+            var shortOption = _commandOptions.Value.FirstOrDefault(option => (option.CommandOptionMetadata.DisplayInfo.ShortName ?? string.Empty).Equals(optionShortName, StringComparison.OrdinalIgnoreCase));
             if (shortOption != null)
             {
-                return shortOption;
+                return shortOption.CommandOption;
             }
             return null;
         }
@@ -79,34 +102,30 @@ namespace MGR.CommandLineParser
 
             var commandActivator = dependencyResolver.ResolveDependency<ICommandActivator>();
             var command = commandActivator.ActivateCommand(Type);
-            var commandBase = command as CommandBase;
             foreach (var commandOption in _commandOptions.Value)
             {
-                commandOption.AssignDefaultValue(command);
+                if (!string.IsNullOrEmpty(commandOption.CommandOptionMetadata.DefaultValue))
+                {
+                    commandOption.CommandOption.AssignValue(commandOption.CommandOptionMetadata.DefaultValue, command);
+                }
             }
+            var commandBase = command as CommandBase;
             commandBase?.Configure(parserOptions, dependencyResolver, this);
             return command;
         }
 
-        private static IEnumerable<ICommandOptionMetadata> ExtractCommandOptionMetadatas(Type commandType, ICommandMetadata commandMetadata)
-        {
-            foreach (var propertyInfo in commandType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(pi => pi.Name != nameof(ICommand.Arguments)))
-            {
-                var commandOption = CommandOptionMetadata.Create(propertyInfo, commandMetadata);
-                if (commandOption != null)
-                {
-                    yield return commandOption;
-                }
-            }
-        }
-        private static IEnumerable<CommandOption> ExtractCommandOptions(Type commandType, ICommandMetadata commandMetadata, List<IConverter> converters)
+        private static IEnumerable<Option> ExtractCommandOptions(Type commandType, ICommandMetadata commandMetadata, List<IConverter> converters)
         {
             foreach (var propertyInfo in commandType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(pi => pi.Name != nameof(ICommand.Arguments)))
             {
                 var commandOption = CommandOption.Create(propertyInfo, commandMetadata, converters);
                 if (commandOption != null)
                 {
-                    yield return commandOption;
+                    var commandOptionMetadata = CommandOptionMetadata.Create(propertyInfo, commandMetadata);
+                    if (commandOptionMetadata != null)
+                    {
+                        yield return new Option(commandOption, commandOptionMetadata);
+                    }
                 }
             }
         }

--- a/src/MGR.CommandLineParser/Extensibility/Command/CommandOption.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/CommandOption.cs
@@ -18,7 +18,6 @@ namespace MGR.CommandLineParser.Extensibility.Command
             PropertyOption = propertyInfo;
             CommandMetadata = commandMetadata;
             DisplayInfo = propertyInfo.ExtractOptionDisplayInfoMetadata();
-            IsRequired = propertyInfo.ExtractIsRequiredMetadata();
             Converter = propertyInfo.ExtractConverter(converters, DisplayInfo.Name, CommandMetadata.Name);
             DefaultValue = propertyInfo.ExtractDefaultValue(ConvertValue);
             _miAddMethod = PropertyOption.PropertyType.GetMethod("Add");
@@ -29,12 +28,7 @@ namespace MGR.CommandLineParser.Extensibility.Command
         /// </summary>
         [NotNull]
         public OptionDisplayInfo DisplayInfo { get; }
-
-        /// <summary>
-        ///     Gets the indication that the option is required.
-        /// </summary>
-        public bool IsRequired { get; }
-
+        
         /// <summary>
         ///     Gets the converter for the option.
         /// </summary>

--- a/src/MGR.CommandLineParser/Extensibility/Command/CommandOptionCollectionType.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/CommandOptionCollectionType.cs
@@ -1,0 +1,23 @@
+﻿namespace MGR.CommandLineParser.Extensibility.Command
+{
+    /// <summary>
+    ///     The different types of collection that an command's option can be.
+    /// </summary>
+    public enum CommandOptionCollectionType
+    {
+        /// <summary>
+        ///     Not a collection.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        ///     A simple collection.
+        /// </summary>
+        Collection = 1,
+
+        /// <summary>
+        ///     A dictionary.
+        /// </summary>
+        Dictionary = 2
+    }
+}

--- a/src/MGR.CommandLineParser/Extensibility/Command/ICommandOption.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/ICommandOption.cs
@@ -1,0 +1,22 @@
+﻿using MGR.CommandLineParser.Command;
+
+namespace MGR.CommandLineParser.Extensibility.Command
+{
+    /// <summary>
+    ///     Represents a command's option.
+    /// </summary>
+    public interface ICommandOption
+    {
+        /// <summary>
+        /// Defines if the value is optional when assigned to the command's option
+        /// </summary>
+        /// <remarks>This is the case for the <see cref="bool"/> for example, where no value indicates a <code>true</code> value.</remarks>
+        bool OptionalValue { get; }
+        /// <summary>
+        /// Assigns a value to the command's option.
+        /// </summary>
+        /// <param name="optionValue"></param>
+        /// <param name="command"></param>
+        void AssignValue(string optionValue, ICommand command);
+    }
+}

--- a/src/MGR.CommandLineParser/Extensibility/Command/ICommandOptionMetadata.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/ICommandOptionMetadata.cs
@@ -1,0 +1,28 @@
+﻿namespace MGR.CommandLineParser.Extensibility.Command
+{
+    /// <summary>
+    ///     Represents the metadata of a command's option.
+    /// </summary>
+    public interface ICommandOptionMetadata
+    {
+        /// <summary>
+        ///     Defines if an option is required or not.
+        /// </summary>
+        bool IsRequired { get; }
+
+        /// <summary>
+        ///     Defines the type of collection of the option.
+        /// </summary>
+        CommandOptionCollectionType CollectionType { get; }
+
+        /// <summary>
+        ///     Gets the display information of the option.
+        /// </summary>
+        OptionDisplayInfo DisplayInfo { get; }
+
+        /// <summary>
+        ///     Gets the default value of the option, if explicitly defined.
+        /// </summary>
+        string DefaultValue { get; }
+    }
+}

--- a/src/MGR.CommandLineParser/Extensibility/Command/ICommandType.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/ICommandType.cs
@@ -23,7 +23,7 @@ namespace MGR.CommandLineParser.Extensibility.Command
         /// <summary>
         /// Gets the option of the command type.
         /// </summary>
-        IEnumerable<CommandOption> Options { get; }
+        IEnumerable<ICommandOptionMetadata> Options { get; }
 
         /// <summary>
         /// Create the command from its type.

--- a/src/MGR.CommandLineParser/Extensibility/Command/ICommandType.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/ICommandType.cs
@@ -37,12 +37,12 @@ namespace MGR.CommandLineParser.Extensibility.Command
         /// </summary>
         /// <param name="optionName">The name (short or long form) of the option.</param>
         /// <returns>The <see cref="CommandOption"/> representing the option of the command.</returns>
-        CommandOption FindOption(string optionName);
+        ICommandOption FindOption(string optionName);
         /// <summary>
         /// Find an option based on its short name.
         /// </summary>
         /// <param name="optionShortName">The short name of the option.</param>
         /// <returns>The <see cref="CommandOption"/> representing the option of the command.</returns>
-        CommandOption FindOptionByShortName(string optionShortName);
+        ICommandOption FindOptionByShortName(string optionShortName);
     }
 }

--- a/src/MGR.CommandLineParser/Extensibility/Command/OptionDisplayInfo.cs
+++ b/src/MGR.CommandLineParser/Extensibility/Command/OptionDisplayInfo.cs
@@ -1,4 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
 
 namespace MGR.CommandLineParser.Extensibility.Command
 {
@@ -10,30 +15,48 @@ namespace MGR.CommandLineParser.Extensibility.Command
         /// <summary>
         ///     Creates a new <see cref="OptionDisplayInfo" />.
         /// </summary>
-        public OptionDisplayInfo()
+        public OptionDisplayInfo(PropertyInfo propertyInfo)
         {
-            AlternateNames = new string[] { };
+            Guard.NotNull(propertyInfo, nameof(propertyInfo));
+            Name = propertyInfo.Name;
+            ShortName = propertyInfo.Name;
+            Description = "";
+            var displayAttribute = propertyInfo.GetCustomAttributes(typeof(DisplayAttribute), true).FirstOrDefault() as DisplayAttribute;
+            if (displayAttribute != null)
+            {
+                Name = displayAttribute.GetName() ?? propertyInfo.Name;
+                ShortName = displayAttribute.GetShortName();
+                Description = displayAttribute.GetDescription();
+            }
+
+            var alternateNames = new List<string>();
+            var nameAsKebabCase = Name.AsKebabCase();
+            if (!nameAsKebabCase.Equals(Name, StringComparison.CurrentCultureIgnoreCase))
+            {
+                alternateNames.Add(nameAsKebabCase);
+            }
+            AlternateNames = alternateNames.AsEnumerable();
         }
 
         /// <summary>
         ///     Gets the name of the option.
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; }
 
         /// <summary>
         ///     Gets the alternates names of the option.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public string[] AlternateNames { get; internal set; }
+        public IEnumerable<string> AlternateNames { get; }
 
         /// <summary>
         ///     Gets the shortname of the option.
         /// </summary>
-        public string ShortName { get; internal set; }
+        public string ShortName { get; }
 
         /// <summary>
         ///     Gets the description of the option.
         /// </summary>
-        public string Description { get; internal set; }
+        public string Description { get; }
     }
 }

--- a/src/MGR.CommandLineParser/Extensibility/DefaultHelpWriter.cs
+++ b/src/MGR.CommandLineParser/Extensibility/DefaultHelpWriter.cs
@@ -89,20 +89,20 @@ namespace MGR.CommandLineParser.Extensibility
                     var maxOptionWidth = commandType.Options.Max(o => o.DisplayInfo.Name.Length + o.DisplayInfo.AlternateNames.Sum(
                         alternateName => alternateName.Length + 1)) + 2;
                     var maxAltOptionWidth = commandType.Options.Max(o => (o.DisplayInfo.ShortName ?? string.Empty).Length);
-                    foreach (var commandOption in commandType.Options)
+                    foreach (var commandOptionMetadata in commandType.Options)
                     {
-                        var alternateNames = string.Join(MultiOptionNameSeparator, commandOption.DisplayInfo.AlternateNames);
+                        var alternateNames = string.Join(MultiOptionNameSeparator, commandOptionMetadata.DisplayInfo.AlternateNames);
                         var prefixAlternateNames = MultiOptionNameSeparator;
                         if (string.IsNullOrEmpty(alternateNames))
                         {
                             prefixAlternateNames = String.Empty;
                         }
-                        var optionName = string.Concat(commandOption.DisplayInfo.Name, prefixAlternateNames, alternateNames, GetMultiValueIndicator(commandOption));
-                        var optionShortName = FormatShortName(commandOption.DisplayInfo.ShortName);
+                        var optionName = string.Concat(commandOptionMetadata.DisplayInfo.Name, prefixAlternateNames, alternateNames, GetMultiValueIndicator(commandOptionMetadata));
+                        var optionShortName = FormatShortName(commandOptionMetadata.DisplayInfo.ShortName);
                         _console.Write(" -{0, -" + maxOptionWidth + "}", optionName);
                         _console.Write("{0, -" + (maxAltOptionWidth + 4) + "}", optionShortName);
 
-                        _console.Write(commandOption.DisplayInfo.Description);
+                        _console.Write(commandOptionMetadata.DisplayInfo.Description);
                         _console.WriteLine();
                     }
                 }
@@ -130,17 +130,17 @@ namespace MGR.CommandLineParser.Extensibility
             _console.WriteLine();
         }
 
-        internal static string GetMultiValueIndicator(CommandOption commandOption)
+        internal static string GetMultiValueIndicator(ICommandOptionMetadata commandOptionMetadata)
         {
-            if (commandOption.PropertyOption.PropertyType.IsCollectionType())
+            switch (commandOptionMetadata.CollectionType)
             {
-                return CollectionIndicator;
+                case CommandOptionCollectionType.Collection:
+                    return CollectionIndicator;
+                case CommandOptionCollectionType.Dictionary:
+                    return DictionaryIndicator;
+                default:
+                    return string.Empty;
             }
-            if (commandOption.PropertyOption.PropertyType.IsDictionaryType())
-            {
-                return DictionaryIndicator;
-            }
-            return string.Empty;
         }
 
         private static string FormatShortName(string shortName)

--- a/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
@@ -149,24 +149,7 @@ namespace System.Reflection
         internal static OptionDisplayInfo ExtractOptionDisplayInfoMetadata(this PropertyInfo source)
         {
             Guard.NotNull(source, nameof(source));
-            var optionDisplayInfo = new OptionDisplayInfo
-            {
-                Name = source.Name,
-                ShortName = source.Name,
-                Description = ""
-            };
-            var displayAttribute = source.GetCustomAttributes(typeof(DisplayAttribute), true).FirstOrDefault() as DisplayAttribute;
-            if (displayAttribute != null)
-            {
-                optionDisplayInfo.Name = displayAttribute.GetName() ?? source.Name;
-                optionDisplayInfo.ShortName = displayAttribute.GetShortName();
-                optionDisplayInfo.Description = displayAttribute.GetDescription();
-            }
-            var nameAsKebabCase = optionDisplayInfo.Name.AsKebabCase();
-            if (!nameAsKebabCase.Equals(optionDisplayInfo.Name, StringComparison.CurrentCultureIgnoreCase))
-            {
-                optionDisplayInfo.AlternateNames = new[] { nameAsKebabCase };
-            }
+            var optionDisplayInfo = new OptionDisplayInfo(source);
             return optionDisplayInfo;
         }
 

--- a/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/PropertyInfoExtensions.cs
@@ -167,6 +167,18 @@ namespace System.Reflection
             }
             return null;
         }
+        internal static string ExtractDefaultValue([NotNull] this PropertyInfo source)
+        {
+            Guard.NotNull(source, nameof(source));
+
+            if (!source.PropertyType.IsMultiValuedType())
+            {
+                var defaultValueAttribute = source.GetCustomAttributes(typeof(DefaultValueAttribute), true).OfType<DefaultValueAttribute>().FirstOrDefault();
+                var originalDefaultValue = defaultValueAttribute?.Value;
+                return originalDefaultValue?.ToString();
+            }
+            return null;
+        }
 
         /// <summary>
         /// Indicates if the given <see cref="PropertyInfo"/> should be ignored as option by the parse.

--- a/src/MGR.CommandLineParser/ParserEngine.cs
+++ b/src/MGR.CommandLineParser/ParserEngine.cs
@@ -108,9 +108,8 @@ namespace MGR.CommandLineParser
                     continue;
                 }
 
-                CommandOption option;
                 int starterLength = 1;
-                Func<ICommandType, string, CommandOption> commandOptionFinder = (_commandType, optionName) => _commandType.FindOption(optionName);
+                Func<ICommandType, string, ICommandOption> commandOptionFinder = (_commandType, optionName) => _commandType.FindOption(optionName);
                 if (argument.StartsWith(Constants.ShortNameOptionStarter))
                 {
                     starterLength = Constants.ShortNameOptionStarter.Length;
@@ -126,24 +125,15 @@ namespace MGR.CommandLineParser
                     optionText = optionText.Substring(0, splitIndex);
                 }
 
-                option = commandOptionFinder(commandType, optionText);
+                var option = commandOptionFinder(commandType, optionText);
                 if (option == null)
                 {
                     throw new CommandLineParserException(Constants.ExceptionMessages.FormatParserOptionNotFoundForCommand(commandType.Metadata.Name, optionText));
                 }
 
-                if (option.OptionType == typeof(bool))
-                {
-                    value = value ?? bool.TrueString;
-                }
-                else
+                if (!option.OptionalValue)
                 {
                     value = value ?? argumentsEnumerator.GetNextCommandLineItem();
-                }
-
-                if (value == null)
-                {
-                    throw new CommandLineParserException(Constants.ExceptionMessages.FormatParserOptionValueRequired(commandType.Metadata.Name, optionText));
                 }
 
                 option.AssignValue(value, command);

--- a/tests/MGR.CommandLineParser.UnitTests/Extensibility/Command/CommandTypeTests.FindOption.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensibility/Command/CommandTypeTests.FindOption.cs
@@ -28,18 +28,18 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility.Command
                 var dependencyResolverScopeMock = new Mock<IDependencyResolverScope>();
                 dependencyResolverScopeMock.Setup(_ => _.ResolveDependency<ICommandActivator>())
                     .Returns(BasicCommandActivator.Instance);
-                var expectedAlternateNames = new[]{"property-list"};
-                var propertyName = nameof(TestCommand.PropertyList);
-                var expectedPropertyInfo = typeof(FindOption.TestCommand).GetProperty(propertyName);
+                var testCommand = testCommandType.CreateCommand(dependencyResolverScopeMock.Object, new ParserOptions()) as TestCommand;
 
                 // Act
                 var actual = testCommandType.FindOption(optionName);
 
                 // Assert
                 Assert.NotNull(actual);
-                Assert.Equal(propertyName, actual.DisplayInfo.Name);
-                Assert.Equal(expectedAlternateNames, actual.DisplayInfo.AlternateNames);
-                Assert.Equal(expectedPropertyInfo, actual.PropertyOption);
+                Assert.NotNull(testCommand);
+                Assert.False(actual.OptionalValue);
+                actual.AssignValue("42", testCommand);
+                Assert.Single(testCommand.PropertyList);
+                Assert.Equal(42, testCommand.PropertyList.First());
 
             }
 

--- a/tests/MGR.CommandLineParser.UnitTests/Extensibility/Command/CommandTypeTests.FindOptionByShortName.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensibility/Command/CommandTypeTests.FindOptionByShortName.cs
@@ -27,18 +27,18 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility.Command
                 var dependencyResolverScopeMock = new Mock<IDependencyResolverScope>();
                 dependencyResolverScopeMock.Setup(_ => _.ResolveDependency<ICommandActivator>())
                     .Returns(BasicCommandActivator.Instance);
-                var expectedAlternateNames = new[]{"property-list"};
-                var propertyName = nameof(TestCommand.PropertyList);
-                var expectedPropertyInfo = typeof(FindOption.TestCommand).GetProperty(propertyName);
+                var testCommand = testCommandType.CreateCommand(dependencyResolverScopeMock.Object, new ParserOptions()) as FindOption.TestCommand;
 
                 // Act
                 var actual = testCommandType.FindOptionByShortName(optionName);
 
                 // Assert
                 Assert.NotNull(actual);
-                Assert.Equal(propertyName, actual.DisplayInfo.Name);
-                Assert.Equal(expectedAlternateNames, actual.DisplayInfo.AlternateNames);
-                Assert.Equal(expectedPropertyInfo, actual.PropertyOption);
+                Assert.NotNull(testCommand);
+                Assert.False(actual.OptionalValue);
+                actual.AssignValue("42", testCommand);
+                Assert.Single(testCommand.PropertyList);
+                Assert.Equal(42, testCommand.PropertyList.First());
 
             }
 

--- a/tests/MGR.CommandLineParser.UnitTests/Extensibility/DefaultHelpWriterTests.GetMultiValueIndicator.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensibility/DefaultHelpWriterTests.GetMultiValueIndicator.cs
@@ -22,7 +22,7 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility
                 var propertyInfo =
                     GetType().GetProperty(TypeHelpers.ExtractPropertyName(() => SimpleIntProperty));
                 var commandMetadata = new CommandMetadata(typeof (GetMultiValueIndicator));
-                var commandOption = CommandOption.Create(propertyInfo, commandMetadata, new List<IConverter> {new Int32Converter()});
+                var commandOption = CommandOptionMetadata.Create(propertyInfo, commandMetadata);
                 var expected = string.Empty;
 
                 // Act
@@ -39,7 +39,7 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility
                 var propertyInfo = GetType()
                     .GetProperty(TypeHelpers.ExtractPropertyName(() => ListIntProperty));
                 var commandMetadata = new CommandMetadata(typeof (GetMultiValueIndicator));
-                var commandOption = CommandOption.Create(propertyInfo, commandMetadata, new List<IConverter> { new Int32Converter()});
+                var commandOption = CommandOptionMetadata.Create(propertyInfo, commandMetadata);
                 var expected = DefaultHelpWriter.CollectionIndicator;
 
                 // Act
@@ -56,8 +56,7 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility
                 var propertyInfo =
                     GetType().GetProperty(TypeHelpers.ExtractPropertyName(() => DictionaryProperty));
                 var commandMetadata = new CommandMetadata(typeof (GetMultiValueIndicator));
-                var commandOption = CommandOption.Create(propertyInfo, commandMetadata,
-                    new List<IConverter> {new StringConverter(), new Int32Converter()});
+                var commandOption = CommandOptionMetadata.Create(propertyInfo, commandMetadata);
                 var expected = DefaultHelpWriter.DictionaryIndicator;
 
                 // Act


### PR DESCRIPTION
The command's options are now splitted in two part:
- metadata for help writing
- value assignement for the parser engine.