### PR TITLE
Use double dash to use the long name to specify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ MGR.CommandLineParser is a multi-command line parser. It uses [System.ComponentM
 
 # How to use it ?
 You can find more docs [here](docs/index.md)
+
 I. **Install MGR.CommandLineParser**
 
 MGR.CommandLineParser is available through [NuGet][nuget]:

--- a/docs/call-command-options.md
+++ b/docs/call-command-options.md
@@ -1,9 +1,8 @@
 # Call command's options
 
 To call an option of a command, you can use the following syntaxes:
-1. /LongOptionName
-2. -LongOptionName
-3. -l
+1. --LongOptionName
+2. -l
 
 when your option have defined as:
 ``` c#

--- a/src/MGR.CommandLineParser/Constants.cs
+++ b/src/MGR.CommandLineParser/Constants.cs
@@ -6,10 +6,11 @@ namespace MGR.CommandLineParser
 {
     internal static class Constants
     {
+        internal static readonly string LongNameOptionStarter = "--";
         internal static readonly string ShortNameOptionStarter = "-";
-        internal static readonly string[] OptionStarter = {"/", ShortNameOptionStarter };
+        internal static readonly string[] OptionStarter = { LongNameOptionStarter, ShortNameOptionStarter };
         internal static readonly char[] OptionSplitter = {':'};
-        internal static readonly string DoubleDash = "--";
+        internal static readonly string EndOfOptions = "--";
         internal const string CommandSuffix = nameof(Command);
 
         internal static class ExceptionMessages

--- a/src/MGR.CommandLineParser/ParserEngine.cs
+++ b/src/MGR.CommandLineParser/ParserEngine.cs
@@ -96,7 +96,7 @@ namespace MGR.CommandLineParser
                 {
                     break;
                 }
-                if (argument.Equals(Constants.DoubleDash))
+                if (argument.Equals(Constants.EndOfOptions))
                 {
                     alwaysPutInArgumentList = true;
                     continue;
@@ -108,13 +108,13 @@ namespace MGR.CommandLineParser
                     continue;
                 }
 
-                int starterLength = 1;
-                Func<ICommandType, string, ICommandOption> commandOptionFinder = (_commandType, optionName) => _commandType.FindOption(optionName);
-                if (argument.StartsWith(Constants.ShortNameOptionStarter))
+                int starterLength = 2;
+                Func<ICommandType, string, ICommandOption> commandOptionFinder = (ct, optionName) => ct.FindOption(optionName);
+                if (!argument.StartsWith(Constants.LongNameOptionStarter))
                 {
                     starterLength = Constants.ShortNameOptionStarter.Length;
                     var defaultCommandOptionFinder = commandOptionFinder;
-                    commandOptionFinder = (_commandType, optionName) => _commandType.FindOptionByShortName(optionName) ?? defaultCommandOptionFinder(_commandType, optionName);
+                    commandOptionFinder = (ct, optionName) => ct.FindOptionByShortName(optionName) ?? defaultCommandOptionFinder(ct, optionName);
                 }
                 var optionText = argument.Substring(starterLength);
                 string value = null;

--- a/tests/MGR.CommandLineParser.IntegrationTests/InvalidArguments/InvalidShortNameFormatTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/InvalidArguments/InvalidShortNameFormatTests.cs
@@ -12,7 +12,7 @@ namespace MGR.CommandLineParser.IntegrationTests.InvalidArguments
             // Arrange
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] {"import", "/p:50"};
+            IEnumerable<string> args = new[] {"import", "--p:50"};
             var expectedMessage = "There is no option 'p' for the command 'Import'.";
 
             // Act & Assert

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/ArgumentsInResponseFileTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/ArgumentsInResponseFileTests.cs
@@ -18,8 +18,8 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             File.WriteAllLines(tempResponseFile, new[]
             {
                 "install",
-                "-version:12.34",
-                "-excludeVersion"
+                "--version:12.34",
+                "--excludeVersion"
             });
 
             // Act

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/CollectionArgumentWithArgumentsTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/CollectionArgumentWithArgumentsTests.cs
@@ -14,7 +14,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
             IEnumerable<string> args = new[]
-                {"IntTest", "-Strvalue:custom value", "-i", "42", "-il", "42", "Custom argument value", "-b"};
+                {"IntTest", "--Strvalue:custom value", "-i", "42", "-il", "42", "Custom argument value", "-b"};
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedStrValue = "custom value";
             var expectedNbOfArguments = 1;

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/CombinedShortSimpleOptionsTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/CombinedShortSimpleOptionsTests.cs
@@ -12,7 +12,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             // Arrange
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] { "pack", "-Version:abc", "-vt" };
+            IEnumerable<string> args = new[] { "pack", "--Version:abc", "-vt" };
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedVersion = "abc";
 
@@ -34,7 +34,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             // Arrange
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] { "pack", "-Version:abc", "-vt:-", "-b" };
+            IEnumerable<string> args = new[] { "pack", "--Version:abc", "-vt:-", "-b" };
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedVersion = "abc";
 

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/SimpleOptionsTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/SimpleOptionsTests.cs
@@ -12,7 +12,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             // Arrange
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] {"delete", "-Source:custom value", "-np", "-ApiKey", "MyApiKey", "Custom argument value", "b"};
+            IEnumerable<string> args = new[] {"delete", "--Source:custom value", "-np", "--ApiKey", "MyApiKey", "Custom argument value", "b"};
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedSource = "custom value";
             var expectedApiKey = "MyApiKey";

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/SimpleOptionsWithArgumentsTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/SimpleOptionsWithArgumentsTests.cs
@@ -46,7 +46,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
             var parserBuild = new ParserBuilder();
             var parser = parserBuild.BuildParser();
             IEnumerable<string> args = new[]
-                {"IntTest", "-Strvalue:custom value", "-i", "42", "Custom argument value", "-b"};
+                {"IntTest", "--Strvalue:custom value", "-i", "42", "Custom argument value", "-b"};
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedStrValue = "custom value";
             var expectedNbOfArguments = 1;

--- a/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/UseHelpOptionTests.cs
+++ b/tests/MGR.CommandLineParser.IntegrationTests/UnspecifiedCommand/UseHelpOptionTests.cs
@@ -15,7 +15,7 @@ namespace MGR.CommandLineParser.IntegrationTests.UnspecifiedCommand
                 .Logo("Display help for list command")
                 .CommandLineName("myListTest.exe");
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] {"list", "/help"};
+            IEnumerable<string> args = new[] {"list", "--help"};
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedResult = 0;
             var expectedHelp = @"Display help for list command
@@ -61,7 +61,7 @@ List sample number 2
                 .Logo("Display help for pack command")
                 .CommandLineName("myPackTest.exe");
             var parser = parserBuild.BuildParser();
-            IEnumerable<string> args = new[] { "pack", "/help" };
+            IEnumerable<string> args = new[] { "pack", "--help" };
             var expectedReturnCode = CommandResultCode.Ok;
             var expectedResult = 0;
             var expectedHelp = @"Display help for pack command


### PR DESCRIPTION
fixes #69 