### PR TITLE
Introduce logging mechanism & some initial logs

### DIFF
--- a/samples/SimpleApp/Program.cs
+++ b/samples/SimpleApp/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Threading;
 using MGR.CommandLineParser;
 using MGR.CommandLineParser.Tests.Commands;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace SimpleApp
 {
@@ -8,26 +11,35 @@ namespace SimpleApp
     {
         private static int Main()
         {
-            Console.ReadLine();
+            //Console.ReadLine();
             var arguments = new[] { "pack", @"MGR.CommandLineParser\MGR.CommandLineParser.csproj", "-Properties", "Configuration=Release", "-Build", "-Symbols", "-MSBuildVersion", "14" };
             var defaultPackArguments = new[] { @"MGR.CommandLineParser\MGR.CommandLineParser.csproj", "-Properties", "Configuration=Release", "-Build", "-Symbols", "-MSBuildVersion", "14" };
             var defaultDeleteArguments = new[] { "delete", @"MGR.CommandLineParser\MGR.CommandLineParser.csproj", "-NoPrompt", "-Source", "source1" };
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddCommandLineParser()
+                .AddLogging(builder => builder
+                    .SetMinimumLevel(LogLevel.Trace)
+                    .AddSeq()
+                    .AddConsole(options => options.IncludeScopes = true));
+            var serviceProvider = serviceCollection.BuildServiceProvider();
             var parserBuild = new ParserBuilder();
-            var parser = parserBuild.BuildParser();
-            var commandResult = parser.Parse(arguments);
-            Console.WriteLine(commandResult.Command);
-            var defaultCommandResult = parser.ParseWithDefaultCommand<PackCommand>(arguments);
-            Console.WriteLine(defaultCommandResult.Command);
+            var parser = parserBuild.BuildParser(serviceProvider);
+            //var commandResult = parser.Parse(arguments);
+            //Console.WriteLine(commandResult.Command);
+
+            //var defaultCommandResult = parser.ParseWithDefaultCommand<PackCommand>(arguments);
+            //Console.WriteLine(defaultCommandResult.Command);
             var defaultPackCommandResult = parser.ParseWithDefaultCommand<PackCommand>(defaultPackArguments);
             Console.WriteLine(defaultPackCommandResult.Command);
-            var defaultDeleteCommandResult = parser.ParseWithDefaultCommand<PackCommand>(defaultDeleteArguments);
-            Console.WriteLine(defaultDeleteCommandResult.Command);
-            Console.ReadLine();
-            if (commandResult.IsValid)
+            //var defaultDeleteCommandResult = parser.ParseWithDefaultCommand<PackCommand>(defaultDeleteArguments);
+            //Console.WriteLine(defaultDeleteCommandResult.Command);
+            //Console.ReadLine();
+            //if (commandResult.IsValid)
             {
-                return commandResult.Execute();
+              //  return commandResult.Execute();
             }
-            return (int)commandResult.ReturnCode;
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            return 0;//(int)commandResult.ReturnCode;
         }
     }
 }

--- a/samples/SimpleApp/SimpleApp.csproj
+++ b/samples/SimpleApp/SimpleApp.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Seq.Extensions.Logging" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\MGR.CommandLineParser\MGR.CommandLineParser.csproj" />
     <ProjectReference Include="..\..\tests\MGR.CommandLineParser.Tests.Commands\MGR.CommandLineParser.Tests.Commands.csproj" />
   </ItemGroup>

--- a/src/MGR.CommandLineParser/Diagnostics/LoggerCategory.cs
+++ b/src/MGR.CommandLineParser/Diagnostics/LoggerCategory.cs
@@ -1,0 +1,10 @@
+﻿
+namespace MGR.CommandLineParser.Diagnostics
+{
+    internal static class LoggerCategory
+    {
+        public class Parser : LoggerCategory<Parser>
+        {
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/Diagnostics/LoggerCategory`1.cs
+++ b/src/MGR.CommandLineParser/Diagnostics/LoggerCategory`1.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace MGR.CommandLineParser.Diagnostics
+{
+    internal abstract class LoggerCategory<T>
+    {
+        public static string Name { get; } = ToName(typeof(T));
+
+        public override string ToString() => Name;
+
+        public static implicit operator string([NotNull] LoggerCategory<T> loggerCategory) => loggerCategory.ToString();
+
+        private static string ToName([NotNull] Type loggerCategoryType)
+        {
+            const string outerClassName = "." + nameof(LoggerCategory);
+
+            var name = loggerCategoryType.FullName.Replace('+', '.');
+            var index = name.IndexOf(outerClassName, StringComparison.Ordinal);
+            if (index >= 0)
+            {
+                name = name.Substring(0, index) + name.Substring(index + outerClassName.Length);
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/Extensibility/AssemblyBrowsingCommandTypeProvider.cs
+++ b/src/MGR.CommandLineParser/Extensibility/AssemblyBrowsingCommandTypeProvider.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using MGR.CommandLineParser.Command;
 using MGR.CommandLineParser.Extensibility.Command;
 using MGR.CommandLineParser.Extensibility.Converters;
+using Microsoft.Extensions.Logging;
 
 namespace MGR.CommandLineParser.Extensibility
 {
@@ -18,6 +19,7 @@ namespace MGR.CommandLineParser.Extensibility
 
         private readonly IEnumerable<IConverter> _converters;
         private readonly IEnumerable<IOptionAlternateNameGenerator> _optionAlternateNameGenerators;
+        private readonly ILogger<AssemblyBrowsingCommandTypeProvider> _logger;
 
         /// <summary>
         /// Create a new <see cref="AssemblyBrowsingCommandTypeProvider"/>.
@@ -25,11 +27,13 @@ namespace MGR.CommandLineParser.Extensibility
         /// <param name="assemblyProvider"></param>
         /// <param name="converters"></param>
         /// <param name="optionAlternateNameGenerators"></param>
-        public AssemblyBrowsingCommandTypeProvider(IAssemblyProvider assemblyProvider, IEnumerable<IConverter> converters, IEnumerable<IOptionAlternateNameGenerator> optionAlternateNameGenerators)
+        /// <param name="logger"></param>
+        public AssemblyBrowsingCommandTypeProvider(IAssemblyProvider assemblyProvider, IEnumerable<IConverter> converters, IEnumerable<IOptionAlternateNameGenerator> optionAlternateNameGenerators, ILogger<AssemblyBrowsingCommandTypeProvider> logger)
         {
             _assemblyProvider = assemblyProvider;
             _converters = converters;
             _optionAlternateNameGenerators = optionAlternateNameGenerators;
+            _logger = logger;
             _commands = new Lazy<Dictionary<string, ICommandType>>(SearchAllCommandTypes);
         }
 

--- a/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.Messages.cs
+++ b/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.Messages.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using MGR.CommandLineParser;
+using MGR.CommandLineParser.Diagnostics;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    internal static partial class LoggerParserExtensions
+    {
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Exception> CreationOfParserEngineAction = LoggerMessage.Define(LogLevel.Debug, CreateParserId(ParserEventId.CreationOfParserEngine), "Creation of the parser engine");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Type, Exception> ParseForSpecificCommandTypeAction = LoggerMessage.Define<Type>(LogLevel.Information, CreateParserId(ParserEventId.ParseForSpecificCommandType), "Parse for a specific command type: '{SpecificCommandType}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Exception> NoCommandFoundAfterSpecificParsingAction = LoggerMessage.Define(LogLevel.Warning, CreateParserId(ParserEventId.NoCommandFoundAfterSpecificParsing), "No command found after parsing a specific type");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Type, CommandResultCode, int, Exception> CommandFoundAfterSpecificParsingAction = LoggerMessage.Define<Type, CommandResultCode, int>(LogLevel.Information, CreateParserId(ParserEventId.CommandFoundAfterSpecificParsing), "Command found after parsing a specific type: Type '{CommandType}', ReturnCode: {ReturnCode}, Number of failed validations: {NbFailedValidations}");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Type, Exception> ParseWithDefaultCommandTypeAction = LoggerMessage.Define<Type>(LogLevel.Information, CreateParserId(ParserEventId.ParseWithDefaultCommandType), "Parsing with default command type: '{DefaultCommandType}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Exception> ArgumentProvidedWithDefaultCommandTypeAction = LoggerMessage.Define<string>(LogLevel.Information, CreateParserId(ParserEventId.ArgumentProvidedWithDefaultCommandType), "Argument provided that can be command name: '{CommandName}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Exception> CommandFoundWithDefaultCommandTypeAction = LoggerMessage.Define<string>(LogLevel.Information, CreateParserId(ParserEventId.CommandFoundWithDefaultCommandType), "Command type found for command name '{CommandName}' when parsing with default command type");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Type, Exception> NoCommandFoundWithDefaultCommandTypeAction = LoggerMessage.Define<string, Type>(LogLevel.Information, CreateParserId(ParserEventId.NoCommandFoundWithDefaultCommandType), "No command found corresponding to commandName: '{CommandName}' when parsing with default command type. Fallback to parsing with specific command using the default command type '{DefaultCommandType}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Type, Exception> NoArgumentProvidedWithDefaultCommandTypeAction = LoggerMessage.Define<Type>(LogLevel.Information, CreateParserId(ParserEventId.NoArgumentProvidedWithDefaultCommandType), "No arguments provided to parse with default command. Fallback to parsing specific command using the default command type '{DefaultCommandType}', but without additional arguments.");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Exception> ParseForNotAlreadyKnownCommandAction = LoggerMessage.Define(LogLevel.Information, CreateParserId(ParserEventId.ParseForNotAlreadyKnownCommand), "Parse arguments for not already known command.");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, Exception> NoCommandNameForNotAlreadyKnownCommandAction = LoggerMessage.Define(LogLevel.Error, CreateParserId(ParserEventId.NoCommandNameForNotAlreadyKnownCommand), "No command name provided for parsing not already known command.");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Exception> ParseUsingCommandNameAction =
+            LoggerMessage.Define<string>(LogLevel.Information, CreateParserId(ParserEventId.ParseUsingCommandName), "Parse using command name '{CommandName}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Exception> NoCommandTypeFoundForNotAlreadyKnownCommandAction =
+            LoggerMessage.Define<string>(LogLevel.Error, CreateParserId(ParserEventId.NoCommandTypeFoundForNotAlreadyKnownCommand), "No CommandType found for the command name '{CommandName}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>, string, Exception> CommandTypeFoundForNotAlreadyKnownCommandAction =
+            LoggerMessage.Define<string>(LogLevel.Information, CreateParserId(ParserEventId.CommandTypeFoundForNotAlreadyKnownCommand), "CommandType found for the command name '{CommandName}'");
+        private static readonly Action<ILogger<LoggerCategory.Parser>,  Exception> ParsedCommandIsNotValidAction =
+            LoggerMessage.Define(LogLevel.Warning, CreateParserId(ParserEventId.ParsedCommandIsNotValid), "Parsed command is not valid");
+
+        private static EventId CreateParserId(ParserEventId eventId) => new EventId((int)eventId, LoggerCategory.Parser.Name + "." + (int)eventId);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CreationOfParserEngine(this ILogger<LoggerCategory.Parser> logger)
+        {
+            CreationOfParserEngineAction(logger, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NoCommandFoundAfterSpecificParsing(this ILogger<LoggerCategory.Parser> logger)
+        {
+            NoCommandFoundAfterSpecificParsingAction(logger, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CommandFoundAfterSpecificParsing(this ILogger<LoggerCategory.Parser> logger, Type commandType, CommandResultCode returnCode, IEnumerable<ValidationResult> validationResults)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                CommandFoundAfterSpecificParsingAction(logger, commandType, returnCode, validationResults.Count(), null);
+            }
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParseForSpecificCommandType(this ILogger<LoggerCategory.Parser> logger, Type specificCommandType)
+        {
+            ParseForSpecificCommandTypeAction(logger, specificCommandType, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParseWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, Type defaultCommandType)
+        {
+            ParseWithDefaultCommandTypeAction(logger, defaultCommandType, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentProvidedWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, string commandName)
+        {
+            ArgumentProvidedWithDefaultCommandTypeAction(logger, commandName, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CommandTypeFoundWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, string commandName)
+        {
+            CommandFoundWithDefaultCommandTypeAction(logger, commandName, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NoCommandTypeFoundWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, string commandName, Type defaultCommandType)
+        {
+            NoCommandFoundWithDefaultCommandTypeAction(logger, commandName, defaultCommandType, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NoArgumentProvidedWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, Type defaultCommandType)
+        {
+            NoArgumentProvidedWithDefaultCommandTypeAction(logger, defaultCommandType, null);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParseForNotAlreadyKnownCommand(this ILogger<LoggerCategory.Parser> logger) =>
+            ParseForNotAlreadyKnownCommandAction(logger, null);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NoCommandNameForNotAlreadyKnownCommand(this ILogger<LoggerCategory.Parser> logger) =>
+            NoCommandNameForNotAlreadyKnownCommandAction(logger, null);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParseUsingCommandName(this ILogger<LoggerCategory.Parser> logger, string commandName) =>
+            ParseUsingCommandNameAction(logger, commandName, null);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NoCommandTypeFoundForNotAlreadyKnownCommand(this ILogger<LoggerCategory.Parser> logger, string commandName) =>
+            NoCommandTypeFoundForNotAlreadyKnownCommandAction(logger, commandName, null);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CommandTypeFoundForNotAlreadyKnownCommand(this ILogger<LoggerCategory.Parser> logger, string commandName) =>
+            CommandTypeFoundForNotAlreadyKnownCommandAction(logger, commandName, null);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ParsedCommandIsNotValid(this ILogger<LoggerCategory.Parser> logger) =>
+            ParsedCommandIsNotValidAction(logger, null);
+    }
+}

--- a/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.Scope.cs
+++ b/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.Scope.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using MGR.CommandLineParser.Diagnostics;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    internal static partial class LoggerParserExtensions
+    {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IDisposable BeginParsingArguments(this ILogger<LoggerCategory.Parser> logger, string correlationId) => logger.BeginScope(new Dictionary<string, object>{{"ParsingId", correlationId}});
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IDisposable BeginParsingForSpecificCommandType(this ILogger<LoggerCategory.Parser> logger, Type specificCommandType)
+        {
+            var scope = logger.BeginScope(new Dictionary<string, object> { { "SpecificCommandType", specificCommandType } });
+            logger.ParseForSpecificCommandType(specificCommandType);
+            return scope;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IDisposable BeginParsingWithDefaultCommandType(this ILogger<LoggerCategory.Parser> logger, Type defaultCommandType)
+        {
+            var scope = logger.BeginScope(new Dictionary<string, object> { { "DefaultCommandType", defaultCommandType } });
+            logger.ParseWithDefaultCommandType(defaultCommandType);
+            return scope;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IDisposable BeginParsingUsingCommandName(this ILogger<LoggerCategory.Parser> logger, string commandName)
+        {
+            var scope = logger.BeginScope(new Dictionary<string, object> { { "CommandName", commandName } });
+            logger.ParseUsingCommandName(commandName);
+            return scope;
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/LoggerParserExtensions.cs
@@ -1,0 +1,25 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    internal static partial class LoggerParserExtensions
+    {
+        private enum ParserEventId
+        {
+            CreationOfParserEngine = 1000,
+            ParseForSpecificCommandType,
+            NoCommandFoundAfterSpecificParsing,
+            CommandFoundAfterSpecificParsing,
+            ParseWithDefaultCommandType,
+            ArgumentProvidedWithDefaultCommandType,
+            CommandFoundWithDefaultCommandType,
+            NoCommandFoundWithDefaultCommandType,
+            NoArgumentProvidedWithDefaultCommandType,
+            ParseForNotAlreadyKnownCommand,
+            NoCommandNameForNotAlreadyKnownCommand,
+            ParseUsingCommandName,
+            NoCommandTypeFoundForNotAlreadyKnownCommand,
+            CommandTypeFoundForNotAlreadyKnownCommand,
+            ParsedCommandIsNotValid
+        }
+    }
+}

--- a/src/MGR.CommandLineParser/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,8 @@ namespace MGR.CommandLineParser
         /// <returns>The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> so that additional calls can be chained.</returns>
         public static IServiceCollection AddCommandLineParser(this IServiceCollection services)
         {
+            services.AddLogging();
+
             services.TryAddSingleton<IConsole, DefaultConsole>();
             services.TryAddSingleton<IAssemblyProvider, CurrentDirectoryAssemblyProvider>();
             services.TryAddScoped<ICommandTypeProvider, AssemblyBrowsingCommandTypeProvider>();

--- a/src/MGR.CommandLineParser/MGR.CommandLineParser.csproj
+++ b/src/MGR.CommandLineParser/MGR.CommandLineParser.csproj
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
The logging is based on the LoggerCategory nested classes to define the
log category (currently only Parser) and on defining LoggerMessage in
the LoggerParserExtensions class (mainly the enum ParserEventId for the
Parser category log).
In some case, creating a scope will also log a message to indicating
entering in a "critical" zone.