### PR TITLE
Add a generic version of ConverterAttribute

### DIFF
--- a/MGR.CommandLineParser.sln
+++ b/MGR.CommandLineParser.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30002.166
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MGR.CommandLineParser", "src\MGR.CommandLineParser\MGR.CommandLineParser.csproj", "{EF6019C2-2C4D-4874-BBBF-D76CA30F7E8D}"
 EndProject

--- a/docs/class-based/customize-class-based-option.md
+++ b/docs/class-based/customize-class-based-option.md
@@ -11,3 +11,6 @@ You can customize the behavior of the options with some annotations (the parser 
   - `Name` and `ShortName` to respectively change the long and short form of the option
   - `Description` to define a description in the auto-generated help for the option,
 - Use any of the `System.ComponentModel.DataAnnotations.ValidationAttribute` derived class to validate the value provided for the option.
+
+If the type of your option is not covered by one of the [built-in converters](../built-in-converters.md),
+you can create and register [your own](../converter.md).

--- a/samples/SimpleApp/SimpleApp.csproj
+++ b/samples/SimpleApp/SimpleApp.csproj
@@ -8,6 +8,7 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <DocumentationFile />
         <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+		<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MGR.CommandLineParser/Command/ConverterAttribute.cs
+++ b/src/MGR.CommandLineParser/Command/ConverterAttribute.cs
@@ -4,9 +4,10 @@ using MGR.CommandLineParser.Extensibility.Converters;
 namespace MGR.CommandLineParser.Command
 {
     /// <summary>
-    /// Defines the converter type for a dictionary property.
+    /// Defines the converter type for a property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
+    [Obsolete("Use the generic version of the MGR.CommandLineParser.Command.ConverterAttribute if you use C#11+")]
     public sealed class ConverterAttribute : Attribute
     {
         /// <summary>

--- a/src/MGR.CommandLineParser/Command/ConverterAttribute`1.cs
+++ b/src/MGR.CommandLineParser/Command/ConverterAttribute`1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using MGR.CommandLineParser.Extensibility.Converters;
+
+namespace MGR.CommandLineParser.Command;
+
+/// <summary>
+/// Defines the converter type for a dictionary property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConverterAttribute<TConverter> : Attribute
+    where TConverter : IConverter
+{ }

--- a/src/MGR.CommandLineParser/Extensions/ConverterAttributeExtensions.cs
+++ b/src/MGR.CommandLineParser/Extensions/ConverterAttributeExtensions.cs
@@ -6,7 +6,9 @@ namespace MGR.CommandLineParser.Command
 {
     internal static class ConverterAttributeExtensions
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         internal static IConverter BuildConverter(this ConverterAttribute source)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             Guard.NotNull(source, nameof(source));
 

--- a/tests/MGR.CommandLineParser.IntegrationTests/MGR.CommandLineParser.IntegrationTests.csproj
+++ b/tests/MGR.CommandLineParser.IntegrationTests/MGR.CommandLineParser.IntegrationTests.csproj
@@ -6,6 +6,7 @@
         <DocumentationFile />
         <IsPackable>false</IsPackable>
         <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+		<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/MGR.CommandLineParser.Tests.Commands/MGR.CommandLineParser.Tests.Commands.csproj
+++ b/tests/MGR.CommandLineParser.Tests.Commands/MGR.CommandLineParser.Tests.Commands.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <DocumentationFile />
         <IsPackable>false</IsPackable>
+		<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/MGR.CommandLineParser.UnitTests/Extensibility/ClassBased/ClassBasedCommandTypeTests.CreateCommand.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensibility/ClassBased/ClassBasedCommandTypeTests.CreateCommand.cs
@@ -43,9 +43,11 @@ namespace MGR.CommandLineParser.UnitTests.Extensibility.ClassBased
             }
             private class TestBadConverterCommand : ICommand
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 [Converter(typeof(BooleanConverter))]
-                // ReSharper disable once UnusedMember.Local
-                // ReSharper disable once UnusedAutoPropertyAccessor.Local
+#pragma warning restore CS0618 // Type or member is obsolete
+                              // ReSharper disable once UnusedMember.Local
+                              // ReSharper disable once UnusedAutoPropertyAccessor.Local
                 public int PropertySimpleWithBadConverter { get; set; }
 
                 #region ICommand Members

--- a/tests/MGR.CommandLineParser.UnitTests/Extensions/ConverterAttributeExtensionsTests.BuildConverter.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensions/ConverterAttributeExtensionsTests.BuildConverter.cs
@@ -14,7 +14,9 @@ namespace MGR.CommandLineParser.UnitTests.Extensions
             {
                 // Arrange
                 var expected = typeof (Int32Converter);
+#pragma warning disable CS0618 // Type or member is obsolete
                 var converterAttribute = new ConverterAttribute(expected);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 // Act
                 var actual = converterAttribute.BuildConverter();
@@ -28,7 +30,9 @@ namespace MGR.CommandLineParser.UnitTests.Extensions
             public void NullConverterAttributeException()
             {
                 // Arrange
+#pragma warning disable CS0618 // Type or member is obsolete
                 ConverterAttribute converterAttribute = null;
+#pragma warning restore CS0618 // Type or member is obsolete
                 var expectedExceptionMessage = SourceParameterName;
 
                 // Act

--- a/tests/MGR.CommandLineParser.UnitTests/Extensions/PropertyInfoExtensionsTests.ExtractConverterMetadata.cs
+++ b/tests/MGR.CommandLineParser.UnitTests/Extensions/PropertyInfoExtensionsTests.ExtractConverterMetadata.cs
@@ -13,15 +13,24 @@ namespace MGR.CommandLineParser.UnitTests.Extensions
         {
             public int OriginalProperty { get; set; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             [Converter(typeof(Int32Converter))]
+#pragma warning restore CS0618 // Type or member is obsolete
             public int CustomConverterProperty { get; set; }
-
+#if NET7_0_OR_GREATER
+            [Converter<Int32Converter>]
+            public int CustomGenericConverterProperty { get; set; }
+#endif
+#pragma warning disable CS0618 // Type or member is obsolete
             [Converter(typeof(GuidConverter))]
+#pragma warning restore CS0618 // Type or member is obsolete
             public int WrongCustomConverterProperty { get; set; }
 
             public List<int> OriginalListProperty { get; set; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             [Converter(typeof(Int32Converter))]
+#pragma warning restore CS0618 // Type or member is obsolete
             public List<int> CustomListConverterProperty { get; set; }
 
             public Dictionary<int, Guid> OriginalDictionaryProperty { get; set; }
@@ -96,7 +105,24 @@ namespace MGR.CommandLineParser.UnitTests.Extensions
                 Assert.NotNull(actual);
                 Assert.IsType<Int32Converter>(actual);
             }
+#if NET7_0_OR_GREATER
+            [Fact]
+            public void CustomGenericConverterTest()
+            {
+                // Arrange
+                var propertyName = TypeHelpers.ExtractPropertyName(() => CustomGenericConverterProperty);
+                var propertyInfo = GetType().GetProperty(propertyName);
+                var commandName = "MyCommand";
+                var converters = new List<IConverter> { new StringConverter() };
 
+                // Act
+                var actual = propertyInfo.ExtractConverter(converters, propertyName, commandName);
+
+                // Assert
+                Assert.NotNull(actual);
+                Assert.IsType<Int32Converter>(actual);
+            }
+#endif
             [Fact]
             public void WrongCustomConverterTest()
             {

--- a/tests/MGR.CommandLineParser.UnitTests/MGR.CommandLineParser.UnitTests.csproj
+++ b/tests/MGR.CommandLineParser.UnitTests/MGR.CommandLineParser.UnitTests.csproj
@@ -6,6 +6,7 @@
         <DocumentationFile />
         <IsPackable>false</IsPackable>
         <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+		<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Mark non generic ConverterAttribute as obsolete if not using C#11+

fixes #150 